### PR TITLE
Add unit tests for vector math components

### DIFF
--- a/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
+++ b/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ARNet.Physics.Tests</RootNamespace>
+    <AssemblyName>ARNet.Physics.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\physics\ARNet.Physics.csproj">
+      <Project>{394D2D64-62E0-419A-966E-0C6E8CA39F73}</Project>
+      <Name>ARNet.Physics</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
+++ b/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\physics\ARNet.Physics.csproj">

--- a/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
+++ b/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ARNet.Physics.Tests</RootNamespace>
     <AssemblyName>ARNet.Physics.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
+++ b/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
@@ -45,6 +45,11 @@
       <Name>ARNet.Physics</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Vec2Tests.cs" />
+    <Compile Include="PhysMathTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
+++ b/ARNet.Physics.Tests/ARNet.Physics.Tests.csproj
@@ -50,6 +50,9 @@
     <Compile Include="PhysMathTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ARNet.Physics.Tests/App.config
+++ b/ARNet.Physics.Tests/App.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.QualityTools.UnitTestFramework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.1.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/ARNet.Physics.Tests/PhysMathTests.cs
+++ b/ARNet.Physics.Tests/PhysMathTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using physics.Engine.Helpers;
+using physics.Engine.Structs;
+using System.Drawing;
+
+namespace ARNet.Physics.Tests
+{
+    [TestClass]
+    public class PhysMathTests
+    {
+        [TestMethod]
+        public void DotProduct_IdenticalVectors_ReturnsSquaredLength()
+        {
+            var p = new PointF(3, 4);
+            var result = PhysMath.DotProduct(p, p);
+            Assert.AreEqual(25m, result);
+        }
+
+        [TestMethod]
+        public void DotProduct_PerpendicularVectors_ReturnsZero()
+        {
+            var p1 = new PointF(1, 0);
+            var p2 = new PointF(0, 1);
+            var result = PhysMath.DotProduct(p1, p2);
+            Assert.AreEqual(0m, result);
+        }
+
+        [TestMethod]
+        public void CorrectBoundingBox_SwappedMinMax_CorrectlySwaps()
+        {
+            var aabb = new AABB
+            {
+                Min = new Vec2(5, 6),
+                Max = new Vec2(1, 2)
+            };
+            PhysMath.CorrectBoundingBox(ref aabb);
+            Assert.AreEqual(1, aabb.Min.X);
+            Assert.AreEqual(2, aabb.Min.Y);
+            Assert.AreEqual(5, aabb.Max.X);
+            Assert.AreEqual(6, aabb.Max.Y);
+        }
+
+        [TestMethod]
+        public void CorrectBoundingBox_AlreadyCorrect_RemainsSame()
+        {
+            var aabb = new AABB
+            {
+                Min = new Vec2(1, 2),
+                Max = new Vec2(5, 6)
+            };
+            PhysMath.CorrectBoundingBox(ref aabb);
+            Assert.AreEqual(1, aabb.Min.X);
+            Assert.AreEqual(2, aabb.Min.Y);
+            Assert.AreEqual(5, aabb.Max.X);
+            Assert.AreEqual(6, aabb.Max.Y);
+        }
+
+        [TestMethod]
+        public void Clamp_ValueInRange_ReturnsValue()
+        {
+            var vector = new Vec2(5, 5);
+            var min = new Vec2(0, 0);
+            var max = new Vec2(10, 10);
+            PhysMath.Clamp(ref vector, min, max);
+            Assert.AreEqual(5, vector.X);
+            Assert.AreEqual(5, vector.Y);
+        }
+
+        [TestMethod]
+        public void Clamp_ValueBelowRange_ClampsToMin()
+        {
+            var vector = new Vec2(-1, -2);
+            var min = new Vec2(0, 0);
+            var max = new Vec2(10, 10);
+            PhysMath.Clamp(ref vector, min, max);
+            Assert.AreEqual(0, vector.X);
+            Assert.AreEqual(0, vector.Y);
+        }
+
+        [TestMethod]
+        public void Clamp_ValueAboveRange_ClampsToMax()
+        {
+            var vector = new Vec2(11, 12);
+            var min = new Vec2(0, 0);
+            var max = new Vec2(10, 10);
+            PhysMath.Clamp(ref vector, min, max);
+            Assert.AreEqual(10, vector.X);
+            Assert.AreEqual(10, vector.Y);
+        }
+
+        [TestMethod]
+        public void RoundToZero_BelowCutoff_SetsToZero()
+        {
+            var vector = new Vec2(0.001f, 0.002f);
+            PhysMath.RoundToZero(ref vector, 0.01f);
+            Assert.AreEqual(0, vector.X);
+            Assert.AreEqual(0, vector.Y);
+        }
+
+        [TestMethod]
+        public void RoundToZero_AboveCutoff_RemainsSame()
+        {
+            var vector = new Vec2(0.1f, 0.2f);
+            PhysMath.RoundToZero(ref vector, 0.01f);
+            Assert.AreEqual(0.1f, vector.X);
+            Assert.AreEqual(0.2f, vector.Y);
+        }
+
+        [TestMethod]
+        public void RadiansToDegrees_ZeroRadians_ReturnsZeroDegrees()
+        {
+            float radians = 0;
+            float degrees = radians.RadiansToDegrees();
+            Assert.AreEqual(0, degrees, 0.0001f);
+        }
+
+        [TestMethod]
+        public void RadiansToDegrees_PiRadians_Returns180Degrees()
+        {
+            float radians = (float)System.Math.PI;
+            float degrees = radians.RadiansToDegrees();
+            Assert.AreEqual(180, degrees, 0.0001f);
+        }
+    }
+}

--- a/ARNet.Physics.Tests/Properties/AssemblyInfo.cs
+++ b/ARNet.Physics.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ARNet.Physics.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ARNet.Physics.Tests")]
+[assembly: AssemblyCopyright("Copyright © 2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+[assembly: Guid("5b5c116e-de45-4d9c-a784-bf3b5e7c7b7a")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ARNet.Physics.Tests/Vec2Tests.cs
+++ b/ARNet.Physics.Tests/Vec2Tests.cs
@@ -1,0 +1,93 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using physics.Engine.Structs;
+
+namespace ARNet.Physics.Tests
+{
+    [TestClass]
+    public class Vec2Tests
+    {
+        [TestMethod]
+        public void Length_ZeroVector_ReturnsZero()
+        {
+            var vec = new Vec2(0, 0);
+            Assert.AreEqual(0, vec.Length);
+        }
+
+        [TestMethod]
+        public void Length_UnitVector_ReturnsOne()
+        {
+            var vec = new Vec2(1, 0);
+            Assert.AreEqual(1, vec.Length);
+        }
+
+        [TestMethod]
+        public void Normalize_NonZeroVector_ReturnsNormalizedVector()
+        {
+            var vec = new Vec2(3, 4);
+            var normalized = Vec2.Normalize(vec);
+            Assert.AreEqual(0.6f, normalized.X, 0.0001f);
+            Assert.AreEqual(0.8f, normalized.Y, 0.0001f);
+        }
+
+        [TestMethod]
+        public void DotProduct_PerpendicularVectors_ReturnsZero()
+        {
+            var v1 = new Vec2(1, 0);
+            var v2 = new Vec2(0, 1);
+            Assert.AreEqual(0, Vec2.DotProduct(v1, v2));
+        }
+
+        [TestMethod]
+        public void Addition_TwoVectors_ReturnsCorrectSum()
+        {
+            var v1 = new Vec2(1, 2);
+            var v2 = new Vec2(3, 4);
+            var sum = v1 + v2;
+            Assert.AreEqual(4, sum.X);
+            Assert.AreEqual(6, sum.Y);
+        }
+
+        [TestMethod]
+        public void Subtraction_TwoVectors_ReturnsCorrectDifference()
+        {
+            var v1 = new Vec2(3, 4);
+            var v2 = new Vec2(1, 2);
+            var diff = v1 - v2;
+            Assert.AreEqual(2, diff.X);
+            Assert.AreEqual(2, diff.Y);
+        }
+
+        [TestMethod]
+        public void Multiplication_VectorByScalar_ReturnsScaledVector()
+        {
+            var vec = new Vec2(2, 3);
+            var scaled = vec * 2;
+            Assert.AreEqual(4, scaled.X);
+            Assert.AreEqual(6, scaled.Y);
+        }
+
+        [TestMethod]
+        public void Division_VectorByScalar_ReturnsDividedVector()
+        {
+            var vec = new Vec2(4, 6);
+            var divided = vec / 2;
+            Assert.AreEqual(2, divided.X);
+            Assert.AreEqual(3, divided.Y);
+        }
+
+        [TestMethod]
+        public void LengthSquared_Vector_ReturnsSquaredLength()
+        {
+            var vec = new Vec2(3, 4);
+            Assert.AreEqual(25, vec.LengthSquared);
+        }
+
+        [TestMethod]
+        public void Equality_SameVectors_ReturnsTrue()
+        {
+            var v1 = new Vec2(1, 2);
+            var v2 = new Vec2(1, 2);
+            Assert.IsTrue(v1 == v2);
+        }
+    }
+}

--- a/PhysicsEngine.sln
+++ b/PhysicsEngine.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ARNet.Physics", "physics\AR
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ARNet.Physics.Tests", "ARNet.Physics.TestsARNet.Physics.Tests.csproj", "{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}"
+EndProject
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection

--- a/PhysicsEngine.sln
+++ b/PhysicsEngine.sln
@@ -1,14 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.1082
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ARNet.Physics", "physics\ARNet.Physics.csproj", "{394D2D64-62E0-419A-966E-0C6E8CA39F73}"
 EndProject
-Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ARNet.Physics.Tests", "ARNet.Physics.Tests\ARNet.Physics.Tests.csproj", "{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}"
 EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
@@ -17,6 +17,10 @@ EndProject
 		{394D2D64-62E0-419A-966E-0C6E8CA39F73}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{394D2D64-62E0-419A-966E-0C6E8CA39F73}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{394D2D64-62E0-419A-966E-0C6E8CA39F73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PhysicsEngine.sln
+++ b/PhysicsEngine.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ARNet.Physics", "physics\AR
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ARNet.Physics.Tests", "ARNet.Physics.TestsARNet.Physics.Tests.csproj", "{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ARNet.Physics.Tests", "ARNet.Physics.Tests\ARNet.Physics.Tests.csproj", "{5B5C116E-DE45-4D9C-A784-BF3B5E7C7B7A}"
 EndProject
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/physics/Engine/Helpers/PhysMath.cs
+++ b/physics/Engine/Helpers/PhysMath.cs
@@ -9,7 +9,7 @@ using physics.Engine.Structs;
 
 namespace physics.Engine.Helpers
 {
-    static class PhysMath
+    public static class PhysMath
     {
 
         public static decimal DotProduct(PointF pa, PointF pb)
@@ -26,6 +26,7 @@ namespace physics.Engine.Helpers
             aabb.Min = new Vec2 { X = p1.X, Y = p1.Y };
             aabb.Max = new Vec2 { X = p2.X, Y = p2.Y };
         }
+
         public static void CorrectBoundingPoints(ref PointF p1, ref PointF p2)
         {
             PointF new_p1 = new PointF(Math.Min(p1.X, p2.X), Math.Min(p1.Y, p2.Y));


### PR DESCRIPTION
Added unit tests for Vec2 and PhysMath components, covering basic vector operations and physics math utilities.

Test coverage includes:
- Vector operations (addition, dot product, normalization)
- Length calculations
- Bounding box corrections
- Vector clamping

Tests were verified to pass locally.

Link to Devin run: https://app.devin.ai/sessions/311982212b434aacb55d1acc6253e6e9
Requested by: Brandon